### PR TITLE
Upgrade argonaut dependencies with typed errors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,16 +15,16 @@
     ],
     "dependencies": {
         "purescript-aff": "^v5.1.2",
-        "purescript-argonaut": "^v6.0.0",
+        "purescript-argonaut": "^v7.0.0",
         "purescript-biscotti-cookie": "^v0.2.0",
         "purescript-effect": "^v2.0.1",
         "purescript-newtype": "^v3.0.0",
         "purescript-ordered-collections": "^v1.6.1",
         "purescript-prelude": "^v4.1.1",
-        "purescript-profunctor-lenses": "^v6.2.0",
+        "purescript-profunctor-lenses": "^v6.3.0",
         "purescript-psci-support": "^v4.0.0",
         "purescript-refs": "^v4.1.0",
         "purescript-test-unit": "^v15.0.0",
-        "purescript-uuid": "^v6.0.0"
+        "purescript-uuid": "^v6.1.0"
     }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,5 +1,5 @@
 let upstream =
-      https://raw.githubusercontent.com/purescript/package-sets/402fbe57afb6c14bf5f5d06a93ceb7e209924abd/src/packages.dhall sha256:095e879c67df226c067f09278a76c179b00371fc086f7ffb7b80503fc10afae7
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200615/packages.dhall sha256:5d0cfad9408c84db0a3fdcea2d708f9ed8f64297e164dc57a7cf6328706df93a
 
 let overrides = {=}
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,7 +1,11 @@
 let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200615/packages.dhall sha256:5d0cfad9408c84db0a3fdcea2d708f9ed8f64297e164dc57a7cf6328706df93a
 
-let overrides = {=}
+let overrides = 
+      { argonaut = upstream.argonaut // { version = "v7.0.0" }
+      , argonaut-codecs = upstream.argonaut-codecs // { version = "v7.0.0" }
+      , argonaut-traversals = upstream.argonaut-traversals // { version = "v8.0.0" }
+      }
 
 let additions = {=}
 

--- a/src/Biscotti/Session/Store/Cookie.purs
+++ b/src/Biscotti/Session/Store/Cookie.purs
@@ -29,7 +29,8 @@ import Prelude
 import Biscotti.Cookie as Cookie
 import Biscotti.Cookie.Types (_value)
 import Biscotti.Session.Store (Destroyer, Getter, SessionStore(..), Setter, Creater)
-import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, encodeJson, jsonParser, stringify)
+import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, encodeJson, parseJson, printJsonDecodeError, stringify)
+import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
 import Data.Lens as Lens
 import Effect.Aff (Aff)
@@ -54,7 +55,7 @@ get :: forall a. DecodeJson a => String -> Getter a
 get secret cookie = do
   value <- decrypt secret $ Cookie.getValue cookie
 
-  pure $ decodeJson =<< jsonParser value
+  pure $ lmap printJsonDecodeError $ decodeJson =<< parseJson value
 
 set :: forall a. EncodeJson a => String -> Setter a
 set secret session cookie = do

--- a/src/Biscotti/Session/Store/Memory.purs
+++ b/src/Biscotti/Session/Store/Memory.purs
@@ -26,7 +26,8 @@ import Prelude
 import Biscotti.Cookie as Cookie
 import Biscotti.Cookie.Types (Cookie)
 import Biscotti.Session.Store (Destroyer, Getter, SessionStore(..), Setter, Creater)
-import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, encodeJson, jsonParser, stringify)
+import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, encodeJson, parseJson, printJsonDecodeError, stringify)
+import Data.Bifunctor (lmap)
 import Data.Either (Either(..), note)
 import Data.Map (Map)
 import Data.Map as Map
@@ -65,9 +66,8 @@ get store cookie = do
   pure do
     key <- getKey cookie
     val <- note "session not found" $ Map.lookup key map
-    json <- jsonParser val
-
-    decodeJson json
+    
+    lmap printJsonDecodeError $ decodeJson =<< parseJson val
 
 set :: forall a. EncodeJson a => Store -> Setter a
 set store session cookie = do


### PR DESCRIPTION
The most recent [major release of the Argonaut library](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v7.0.0) introduces typed errors, which affects the call to `get` in this library.

This PR updates the library to be compatible with the latest Argonaut version both via Bower and Spago. I've verified the project installs, builds, and passes tests with both package managers.

The overrides in the `spago.dhall` files can be removed as soon as the next package set is released, as tracked by this issue:
https://github.com/purescript/package-sets/issues/642

To make sure that everything remains compatible through the next package sets release with minimum hassle, I suggest:

1. Make a new release with this updated code, so that it is compatible with the upcoming package set
2. Once the release is complete, remove the overrides from the `spago.dhall` file as they are no longer necessary

Sorry for the hassle! Thanks!